### PR TITLE
Fix missing dependency on ghc-api-compat

### DIFF
--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -219,7 +219,8 @@ test-suite bios-tests
       filepath,
       directory,
       temporary,
-      ghc
+      ghc,
+      ghc-api-compat
 
   hs-source-dirs: tests/
   ghc-options: -threaded -Wall


### PR DESCRIPTION
Fixes the following error:
```
Preprocessing test suite 'bios-tests' for hie-bios-0.7.5..
Building test suite 'bios-tests' for hie-bios-0.7.5..
[1 of 1] Compiling Main             ( tests/BiosTests.hs, dist/build/bios-tests/bios-tests-tmp/Main.dyn_o )

tests/BiosTests.hs:29:1: error:
    Could not load module ‘DynFlags’
    It is a member of the hidden package ‘ghc-api-compat-8.6.1’.
    Perhaps you need to add ‘ghc-api-compat’ to the build-depends in your .cabal file.
    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
   |
29 | import DynFlags (dynamicGhc)
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```